### PR TITLE
made workspace name unique string to fix error

### DIFF
--- a/Hands-on lab/Scripts/template.json
+++ b/Hands-on lab/Scripts/template.json
@@ -38,7 +38,7 @@
   "resources": [
     {
       "type": "microsoft.operationalinsights/workspaces",
-      "name": "azsecuritylogging",
+      "name": "[concat('azsecuritylogging',uniqueString(resourceGroup().id))]",
       "apiVersion": "2015-11-01-preview",
       "location": "eastus",
       "scale": null,


### PR DESCRIPTION
Deployment of the workspace fails because the name is not gobally unique. Added a unique string generation to fix.