### PR TITLE
Removed invalid character from package.json

### DIFF
--- a/Hands-on lab/WebApp/InsuranceAPI/InsuranceAPI/packages.config
+++ b/Hands-on lab/WebApp/InsuranceAPI/InsuranceAPI/packages.config
@@ -1,4 +1,4 @@
-﻿+<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net461" />
   <package id="bootstrap" version="4.3.1" targetFramework="net461" />


### PR DESCRIPTION
This PR is in response to issue #48 

I was unable to reproduce the issue experienced with SQL Server Management Studio not prompting to add the client IP address as a firewall rule. I would advise to ensure the latest version of SQL Server Management Studio is installed.

Fixed the issue with the excess character being present in the packages.config file.